### PR TITLE
Add dependabot for GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test-dependabot.yml
+++ b/.github/workflows/test-dependabot.yml
@@ -1,0 +1,32 @@
+name: Check dependabot update
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/*.yml
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  test-feature:
+    uses: ./.github/workflows/test-feature.yml
+  dependabot-auto-approve:
+    needs:
+      - test-feature
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.6.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add dependabot for GitHub Actions dependencies
- Add GitHub Actions workflow for auto merge PR by dependabot

ref. [Automating Dependabot with GitHub Actions - GitHub Docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)